### PR TITLE
Update Go Library with Changes from Skyramp v1.2.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.7
 
 require (
-	github.com/docker/docker v27.2.1+incompatible
+	github.com/docker/docker v28.0.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/docker v27.2.1+incompatible h1:fQdiLfW7VLscyoeYEBz7/J8soYFDZV1u6VW6gJEjNMI=
-github.com/docker/docker v27.2.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
+github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/lcm/docker.go
+++ b/lcm/docker.go
@@ -290,8 +290,8 @@ func findContainerByName(containerName string) (*dockerTypes.Container, error) {
 	return nil, fmt.Errorf("container %s not found", containerName)
 }
 
-func (d *DockerLCM) FindNetworkByName(networkName string) (*dockerTypes.NetworkResource, error) {
-	networks, err := d.client.NetworkList(context.Background(), dockerTypes.NetworkListOptions{})
+func (d *DockerLCM) FindNetworkByName(networkName string) (*network.Inspect, error) {
+	networks, err := d.client.NetworkList(context.Background(), network.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (d *DockerLCM) FindNetworkByName(networkName string) (*dockerTypes.NetworkR
 		return nil, fmt.Errorf("failed to find network %s", networkID)
 	}
 
-	network, err := d.client.NetworkInspect(context.Background(), networkID, dockerTypes.NetworkInspectOptions{})
+	network, err := d.client.NetworkInspect(context.Background(), networkID, network.InspectOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Automated changes proposed by release of Skyramp v1.2.23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `github.com/docker/docker` to v28.0.0 and updates `FindNetworkByName` to new network types/options.
> 
> - **Dependencies**:
>   - Upgrade `github.com/docker/docker` from `v27.2.1` to `v28.0.0`.
> - **LCM (Docker)**:
>   - Update `lcm/docker.go` `FindNetworkByName`:
>     - Return type changed from `*dockerTypes.NetworkResource` to `*network.Inspect`.
>     - Replace `dockerTypes.NetworkListOptions` with `network.ListOptions` and `dockerTypes.NetworkInspectOptions` with `network.InspectOptions`.
>   - Adjust corresponding Docker client calls to match v28 APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2152f93eeeed51cb525230ac0586bb04a8e79df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->